### PR TITLE
I will update .npmignore to exclude docs/.vitepress/dist/ and docs/.v…

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ yarn-error.log
 .idea/
 .vscode/
 pdf/
-docs/.vitepress/cache
-docs/.vitepress/dist
+docs/.vitepress/cache/
+docs/.vitepress/dist/
 *.pdf

--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,6 @@ yarn-debug.log
 yarn-error.log
 README.md
 export-pdf.ts
-tsconfig.json 
+tsconfig.json
+docs/.vitepress/dist/
+docs/.vitepress/cache/

--- a/README.md
+++ b/README.md
@@ -12,16 +12,20 @@
 VitePressサーバーが起動している状態で、プロジェクトのルートディレクトリから以下のコマンドを実行します。
 
 ```bash
-npx export-pdf --url http://localhost:5173/apple-ecosystem/index.html
+npx export-pdf --url <URL> --out <出力パス>
 ```
 
 ### オプション
 
-- `--url` ... PDF化したいページのURL（例: http://localhost:5173/apple-ecosystem/index.html）
+- `--url` ... PDF化したいページのURL（例: `http://localhost:5173/index.html`）
+- `--out` ... PDFの出力先パス（例: `./output.pdf`）
 
-## 出力先
+### 実行例
 
-生成されたPDFファイルは、すべて `packages/export-pdf/pdf/` ディレクトリに保存されます。
-URLの末尾ファイル名（.html→.pdf変換）で保存されます。
+```bash
+npx export-pdf --url http://localhost:5173/index.html --out ./vitepress.pdf
+```
 
-例: `http://localhost:5173/apple-ecosystem/index.html` → `packages/export-pdf/pdf/index.pdf`
+## 出力
+
+指定された出力パスにPDFファイルが生成されます。

--- a/sources/export-pdf.ts
+++ b/sources/export-pdf.ts
@@ -13,8 +13,7 @@ import * as fs from 'fs';
         if (args[i] === '--url' && args[i + 1]) {
             urlArg = args[i + 1];
             i++;
-        }
-        if (args[i] === '--out' && args[i + 1]) {
+        } else if (args[i] === '--out' && args[i + 1]) {
             outArg = args[i + 1];
             i++;
         }


### PR DESCRIPTION
…itepress/cache/ from the npm package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `.gitignore` にてディレクトリ指定を明確化しました。
  * `.npmignore` にビルドキャッシュと出力ディレクトリを追加し、不要なファイルの公開を防止しました。

* **テスト**
  * E2EテストでVitePressサーバーの起動と待機処理を改善し、動的ポート割り当てに対応しました。

* **その他**
  * CIパイプラインのワークフローで利用するアクションのバージョンを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->